### PR TITLE
remove console.logs in production

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "production": {
+      "plugins": ["transform-remove-console"]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3535,8 +3535,7 @@
     "babel-plugin-transform-remove-console": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
-      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
-      "dev": true
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A="
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.9.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@storybook/addon-notes": "^5.1.11",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "core-js": "^2.6.5",
     "font-awesome": "^4.7.0",
     "history": "^4.10.1",


### PR DESCRIPTION
In this pull request I added babel plugin for remove console.logs from production code.